### PR TITLE
Update 504.xml

### DIFF
--- a/504.xml
+++ b/504.xml
@@ -52,7 +52,7 @@ https://www.omaspecworks.org/about/intellectual-property-rights/
 		<Mandatory>Optional</Mandatory>
 		<Resources>
 			<Item ID="0">
-				<Name>Current UIM Type</Name>
+				<Name>Current SIM Type</Name>
 				<Operations>R</Operations>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Mandatory</Mandatory>
@@ -60,115 +60,129 @@ https://www.omaspecworks.org/about/intellectual-property-rights/
 				<RangeEnumeration></RangeEnumeration>
 				<Units></Units>
 				<Description><![CDATA[Provides the information about the currently being used SIM Type:
-0: Full Size
-1: Mini Size
-2: Micro
-3: Nano
-4: eSIM
-5: UICC
-6: Soft SIM
-7: Thin SIM
-8: eUICC
-9: iSIM
-10: iUICC
-11-24: Reserved for future use]]></Description>
+0: UICC (removable)
+1: eUICC (removable)
+2: eUICC (non-removable)
+3: iUICC
+4-24: Reserved for future use]]></Description>
 			</Item>
 			<Item ID="1">
 				<Name>Supported SIM Type</Name>
 				<Operations>R</Operations>
-				<MultipleInstances>Single</MultipleInstances>
+				<MultipleInstances>Multiple</MultipleInstances>
 				<Mandatory>Mandatory</Mandatory>
 				<Type>Integer</Type>
 				<RangeEnumeration></RangeEnumeration>
 				<Units></Units>
 				<Description><![CDATA[Provides the information about the currently supported SIM Types: 
-0: Full Size
-1: Mini Size
-2: Micro
-3: Nano
-4: eSIM
-5: UICC
-6: Soft SIM
-7: Thin SIM
-8: eUICC
-9: iSIM
-10: iUICC
-11-24: Reserved for future use]]></Description>
+0: UICC (removable)
+1: eUICC (removable)
+2: eUICC (non-removable)
+3: iUICC
+4-24: Reserved for future use]]></Description>
 			</Item>
 			<Item ID="2">
-				<Name>Service Provide Name</Name>
+				<Name>Service Provider Name</Name>
 				<Operations>R</Operations>
 				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Mandatory</Mandatory>
+				<Mandatory>Optional</Mandatory>
 				<Type>String</Type>
 				<RangeEnumeration></RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[Provides the Service Provider Name using which LwM2M is currently communicating to the Server]]></Description>
+				<Description><![CDATA[Provides the name of the Service Provider assocatiated with the downloaded profile or the profile currently being downloaded.]]></Description>
 			</Item>
 			<Item ID="3">
 				<Name>Profile Package</Name>
 				<Operations>W</Operations>
 				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Mandatory</Mandatory>
+				<Mandatory>Optional</Mandatory>
 				<Type>Opaque</Type>
 				<RangeEnumeration></RangeEnumeration>
 				<Units></Units>
 				<Description><![CDATA[Profile Package is a personalised Profile using an interoperable description format that is transmitted to an eUICC to load and install a Profile.]]></Description>
 			</Item>
 			<Item ID="4">
-				<Name>Profile URI</Name>
+				<Name>Download URI/Information</Name>
 				<Operations>RW</Operations>
 				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Mandatory</Mandatory>
+				<Mandatory>Optional</Mandatory>
 				<Type>String</Type>
 				<RangeEnumeration>0..255</RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[URI from where the device can download the profile package by an alternative mechanism. As soon the device has received the Profile package URI it performs the download at the next practical opportunity. The URI format is defined in RFC 3986. For example, coaps://example.org/profile is a syntactically valid URI. The URI scheme determines the protocol to be used. For CoAP this endpoint MAY be a LwM2M Server but does not necessarily need to be. A CoAP server implementing block-wise transfer is sufficient as a server hosting a firmware repository and the expectation is that this server merely serves as a separate file server making profile images available to LwM2M Clients. This server can be the future carrier server as well from which IoT devices would like to use the service.]]></Description>
+				<Description><![CDATA[URI, or formatted data containing the URI (e.g. GSMA SGP.22 Activation Code), from where the device can download the profile package by an alternative mechanism. 
+The URI format is defined in RFC 3986. For example, coaps://example.org/profile is a syntactically valid URI. The URI scheme determines the protocol to be used. For CoAP this endpoint MAY be a LwM2M Server
+but does not necessarily need to be. A CoAP server implementing block-wise transfer is sufficient as a server hosting a firmware repository and the expectation is that this server merely serves as a separate
+file server making profile images available to LwM2M Clients. This server can be the future carrier server as well from which IoT devices would like to use the service.]]></Description>
 			</Item>
 			<Item ID="5">
-				<Name>Profile Update</Name>
+				<Name>RSP Update</Name>
 				<Operations>E</Operations>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>
-				<Type></Type>
-				<RangeEnumeration></RangeEnumeration>
+				<Type>String</Type>
+				<RangeEnumeration>0..5</RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[Updates profile by using the profile package stored in Package, or, by using the profile downloaded from the Package URI. This Resource is only executable when the value of the State Resource is Downloaded.]]></Description>
+				<Description><![CDATA[Executes one or more RSP actions. The actions are given as arguments and in case providing multiple actions comma separation is used, e.g. 0,1,2. The following values are possible:
+0: Download profile
+1: Install profile
+2: Enable profile - for profile identified by resource 26
+3: Disable profile - for profile identified by resource 26
+4: Delete profile - for profile identified by resource 26
+5: Reset memory of current SIM
+6-24: Reserved for future use]]></Description>
 			</Item>
 			<Item ID="6">
-				<Name>State</Name>
+				<Name>RSP Update State</Name>
 				<Operations>R</Operations>
 				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Mandatory</Mandatory>
+				<Mandatory>Optional</Mandatory>
 				<Type>Integer</Type>
-				<RangeEnumeration>0..3</RangeEnumeration>
+				<RangeEnumeration>0..10</RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[Indicates current state with respect to this profile update. This value is set by the LwM2M Client. 
-0: Idle (before downloading or after successful updating) 
-1: Downloading (The data sequence is on the way) 
-2: Downloaded 
-3: Updating If writing the profile package to Package Resource is done, or, if the device has downloaded the profile package from the Package URI the state changes to Downloaded. Writing an empty string to Package URI Resource or setting the Package Resource to NULL (â€˜\0â€™), resets the Profile Update State Machine: the State Resource value is set to Idle and the Update Result Resource value is set to 0. When in Downloaded state, and the executable Resource Update is triggered, the state changes to Updating. If the Update Resource failed, the state returns at Downloaded. If performing the Update Resource was successful, the state changes from Updating to Idle.]]></Description>
+				<Description><![CDATA[Indicates current state with respect to the executed RSP action(s) in the RSP update resource. This value is set by the LwM2M Client.
+0: Idle (before downloading a profile or after successful completetion of the action(s))
+1: Downloading (The data sequence is on the way)
+2: Downloaded profile ready for installation
+3: Installing
+5: Enabling
+6: Disabling
+7: Deleting
+8: Resetting memory
+9: Pending end-user consent
+10: Pending confirmation code
+11-24: Reserved for future use]]></Description>
 			</Item>
 			<Item ID="7">
-				<Name>Update Result</Name>
+				<Name>RSP Update Result</Name>
 				<Operations>R</Operations>
 				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Mandatory</Mandatory>
+				<Mandatory>Optional</Mandatory>
 				<Type>Integer</Type>
-				<RangeEnumeration>0..9</RangeEnumeration>
+				<RangeEnumeration>0..16</RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[Contains the result of downloading or updating the Profile 
-
+				<Description><![CDATA[Contains the result of the executed RSP action(s) in the RSP update resource.
 0: Initial value. Once the updating process is initiated (Download /Update), this Resource MUST be reset to Initial value. 
-1: Profile updated successfully, 
+1: RSP action completed successfully.
 2: Not enough SIM memory for the new Profile package. 
 3. Out of RAM during downloading process. 
-4: Connection lost during downloading process. 5: Integrity check failure for new downloaded package. 
-6: Unsupported package type. 
+4: Connection lost during downloading process.
+5: Integrity check failure for new downloaded profile package. 
+6: Unsupported profile package type. 
 7: Invalid URI
-8: Unsupported protocol. 
+8: Unsupported protocol.
+9: Not authorized to download profile at the given URI.
+10: Failed to authenticate server given by the URI.
+11: Generic download and installation error.
+12: Error in profile package format
+13: Failed to enable profile.
+14: Failed to disable profile.
+15: Failed to delete profile.
+16: Failed to reset memory.
+17-24: Reserved for future use
 
-A LwM2M client indicates the failure to retrieve the Profile using the URI provided in the Package URI resource by writing the value 9 to the /x/0/7 (Update Result resource) when the URI contained a URI scheme unsupported by the client. Consequently, the LwM2M Client is unable to retrieve the Profile using the URI provided by the LwM2M Server in the Package URI when it refers to an unsupported protocol.]]></Description>
+A LwM2M client indicates the failure to retrieve the Profile using the URI provided in the Download URI/Information resource by writing the value 8 to the /x/0/7 (Update Result resource) when the URI contained
+a URI scheme unsupported by the client. Consequently, the LwM2M Client is unable to retrieve the Profile using the URI provided by the LwM2M Server in the Download URI/Information when it refers to an unsupported
+protocol.]]></Description>
 			</Item>
 			<Item ID="8">
 				<Name>Profile Name</Name>
@@ -178,7 +192,7 @@ A LwM2M client indicates the failure to retrieve the Profile using the URI provi
 				<Type>String</Type>
 				<RangeEnumeration>0..255</RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[Name of the Profile Package]]></Description>
+				<Description><![CDATA[Name of the downloaded profile / profile package or the profile / profile package currently being downloaded.]]></Description>
 			</Item>
 			<Item ID="9">
 				<Name>Profile Package Version</Name>
@@ -188,41 +202,39 @@ A LwM2M client indicates the failure to retrieve the Profile using the URI provi
 				<Type>String</Type>
 				<RangeEnumeration>0..255</RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[Version of the Profile package]]></Description>
+				<Description><![CDATA[Version of the downloaded profile / profile package or the profile / profile package currently being downloaded.]]></Description>
 			</Item>
 			<Item ID="10">
-				<Name>Profile Update Protocol Support</Name>
+				<Name>RSP Update Protocol Support</Name>
 				<Operations>R</Operations>
 				<MultipleInstances>Multiple</MultipleInstances>
 				<Mandatory>Optional</Mandatory>
 				<Type>Integer</Type>
 				<RangeEnumeration></RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[This resource indicates what protocols the LwM2M Client implements to retrieve Profiles. The LwM2M server uses this information to decide what URI to include in the Package URI. A LwM2M Server MUST NOT include a URI in the Package URI object that uses a protocol that is unsupported by the LwM2M client. For example, if a LwM2M client indicates that it supports CoAP and CoAPS then a LwM2M Server must not provide an HTTP URI in the Packet URI. The following values are defined by this version of the specification: 
-0 - CoAP (as defined in RFC 7252) with the additional support for block-wise transfer. CoAP is the default setting. 
-1 - CoAPS (as defined in RFC 7252) with the additional support for block-wise transfer 
-2 - HTTP 1.1 (as defined in RFC 7230) 
-3 - HTTPS 1.1 (as defined in RFC 7230) Additional values MAY be defined in the future. Any value not understood by the LwM2M Server MUST be ignored.]]></Description>
+				<Description><![CDATA[This resource indicates what protocols the LwM2M Client implements to retrieve Profiles. The LwM2M server uses this information to decide what URI to include in the
+Download URI/Information. A LwM2M Server MUST NOT include a URI in the Download URI/Information resource that uses a protocol that is unsupported by the LwM2M client. For example, if a LwM2M client indicates
+that it supports CoAP and CoAPS then a LwM2M Server must not provide an HTTP URI in the Packet URI. The following values are defined by this version of the specification: 
+0: CoAP (as defined in RFC 7252) with the additional support for block-wise transfer. CoAP is the default setting. 
+1: CoAPS (as defined in RFC 7252) with the additional support for block-wise transfer 
+2: HTTP 1.1 (as defined in RFC 7230) 
+3: HTTPS 1.1 (as defined in RFC 7230) Additional values MAY be defined in the future. Any value not understood by the LwM2M Server MUST be ignored.]]></Description>
 			</Item>
 			<Item ID="11">
-				<Name>Profile Update Delivery  Method</Name>
+				<Name>Profile Download Delivery Method</Name>
 				<Operations>R</Operations>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Mandatory</Mandatory>
 				<Type>Integer</Type>
 				<RangeEnumeration></RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[The LwM2M Client uses this resource to
-indicate its support for transferring Profile
-images to the client either via the Package
-Resource (=push) or via the Package URI
-Resource (=pull) mechanism.
-0 - Pull only
-1 - Push only
-2 - Both. In this case the LwM2M Server
-MAY choose the preferred mechanism for
-conveying the profile image to the
-LwM2M Client.]]></Description>
+				<Description><![CDATA[The LwM2M Client uses this resource to indicate its support for transferring Profile packages to the client either via the Profile Package Resource (=push) or
+through downloading using the Download URI/Information Resource (=pull). Alternatively, new profile packages are transferred to the current SIM without LwM2M Client involvement.
+0: Pull only
+1: Push only
+2: Both. In this case the LwM2M Server MAY choose the preferred mechanism for conveying the profile image to the LwM2M Client.
+3: RSP management performed outside of LwM2M (e.g. change of SIM card, SMS triggered management).
+In case of options 0, 1, or 2 the LwM2M client provides, in addition to resource 3 or 4, at least resources 5, 6, and 7.]]></Description>
 			</Item>
 			<Item ID="12">
 				<Name>Free Memory on SIM</Name>
@@ -327,22 +339,24 @@ LwM2M Client.]]></Description>
 			<Item ID="22">
 				<Name>Integrated Circuit Card Identifier (ICCID)</Name>
 				<Operations>R</Operations>
-				<MultipleInstances>Single</MultipleInstances>
-				<Mandatory>Optional</Mandatory>
-				<Type>Integer</Type>
+				<MultipleInstances>Multiple</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>String</Type>
 				<RangeEnumeration></RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[This EF provides a unique identification number for the UICC/Smart Cards. Please refer ETSI TS 102.22.1]]></Description>
+				<Description><![CDATA[This resource provides the unique identification number for each installed profile of the current SIM in case of RSP support or
+the unique identification number of the current SIM in case of current SIM being a UICC with no RSP support. Please refer ETSI TS 102.22.1. In case of multiple installed profiles,
+the currently active profile is the first instance.]]></Description>
 			</Item>
 			<Item ID="23">
 				<Name>eUICC ID</Name>
 				<Operations>R</Operations>
 				<MultipleInstances>Single</MultipleInstances>
 				<Mandatory>Optional</Mandatory>
-				<Type>Integer</Type>
+				<Type>String</Type>
 				<RangeEnumeration></RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[eUICC-ID as defined in SGP.02 spec]]></Description>
+				<Description><![CDATA[eUICC-ID (a.k.a. EID), see GSMA SGP.02 and GSMA SGP.29 for definitions]]></Description>
 			</Item>
 			<Item ID="24">
 				<Name>Profile Type</Name>
@@ -352,7 +366,117 @@ LwM2M Client.]]></Description>
 				<Type>Integer</Type>
 				<RangeEnumeration></RangeEnumeration>
 				<Units></Units>
-				<Description><![CDATA[Operator specific defined type of Profile. This is equivalent to the "Profile Description ID" as described in Annex B of SGP.21 [4]]]></Description>
+				<Description><![CDATA[Operator specific defined type of Profile. This is equivalent to the "Profile Description ID" as described in Annex B of GSMA SGP.21 [4]]]></Description>
+			</Item>
+			<Item ID="25">
+				<Name>RSP Type</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Mandatory</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Provides the information about the Remote SIM Provisioning (RSP) type of the current SIM:
+0: No RSP support
+1: GSMA eSIM for M2M devices
+2: GSMA eSIM for consumer devices
+3: nuSIM
+4-24: Reserved for future use]]></Description>
+			</Item>
+			<Item ID="26">
+				<Name>Selected ICCID for RSP operation</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Indicates ICCID of profile selected for profile specific RSP operations. This resource must be present if multiple installed profiles is supported
+by the RSP implementation. In case of only support for a single profile at a time this resource is not required to be present for profile selection. After successful installation of
+a profile the value of this resource (if present) is updated to the ICCID of the installed profile.]]></Description>
+			</Item>
+			<Item ID="27">
+				<Name>RSP Consent Reason</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Provides information on the requested user consent]]></Description>
+			</Item>
+			<Item ID="28">
+				<Name>RSP User Consent</Name>
+				<Operations>W</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..1</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[User consent decision. The following values are possible:
+0: Approved
+1: Rejected
+2-24: Reserved for future use]]></Description>
+			</Item>
+			<Item ID="29">
+				<Name>RSP Confirmation Code</Name>
+				<Operations>W</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>String</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[Provides a confirmation code (see e.g. GSMA SGP.21/22)]]></Description>
+			</Item>
+			<Item ID="30">
+				<Name>RSP Data Type</Name>
+				<Operations>RW</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Integer</Type>
+				<RangeEnumeration>0..17</RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[RSP data type for set and get RSP data:
+0: SM-DP+ default address (see GSMA SGP.22)
+1: eUICCInfo2 (see GSMA SGP.22)
+2: DeviceInfo (see GSMA SGP.22)
+3: eSIM Profile Metadata (GSMA SGP.22 ProfileInfo default data for all installed profiles)
+5: ISD-P AID (see GSMA SGP.22) - for profile identified by resource 26
+6: Profile state (see GSMA SGP.22) - for profile identified by resource 26
+7: Profile Nickname (see GSMA SGP.22) - for profile identified by resource 26
+8: Service provider name (see GSMA SGP.22) - for profile identified by resource 26
+9: Profile name (see GSMA SGP.22) - for profile identified by resource 26
+10: Icon type (see GSMA SGP.22) - for profile identified by resource 26
+11: Icon (see GSMA SGP.22) - for profile identified by resource 26
+12: Profile Class (see GSMA SGP.22) - for profile identified by resource 26
+13: Notification Configuration Info (see GSMA SGP.22) - for profile identified by resource 26
+14: Profile Owner (see GSMA SGP.22) - for profile identified by resource 26
+15: SM-DP+ proprietary data (see GSMA SGP.22) - for profile identified by resource 26
+16: Profile Policy Rules (see GSMA SGP.22) - for profile identified by resource 26
+17: RSP formatted data request/response (RSP type specific)
+18-24: Reserved for future use]]></Description>
+			</Item>
+			<Item ID="31">
+				<Name>Set RSP Data</Name>
+				<Operations>W</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Opaque</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[This resource is used to update the (e/i)UICC data / profile specific data of type according to resource 30.
+It is up to the RSP type whether update of the data is possible or not.]]></Description>
+			</Item>
+			<Item ID="32">
+				<Name>Get RSP Data</Name>
+				<Operations>R</Operations>
+				<MultipleInstances>Single</MultipleInstances>
+				<Mandatory>Optional</Mandatory>
+				<Type>Opaque</Type>
+				<RangeEnumeration></RangeEnumeration>
+				<Units></Units>
+				<Description><![CDATA[This resource is used to retrieve the (e/i)UICC data / profile specific data of type according to resource 30.
+It is up to the RSP type whether retrieval of the data is possible or not.]]></Description>
 			</Item>
 		</Resources>
 		<Description2 />


### PR DESCRIPTION
Ericsson agrees to make a Remote SIM Provisioning object that works with GSMA eSIM for consumer devices, GSMA eSIM for M2M devices and nuSIM. Here changes are proposed to better support the different RSP types.
